### PR TITLE
LWW, Wiley, Highwire crawler fixes

### DIFF
--- a/pubMunch/__init__.py
+++ b/pubMunch/__init__.py
@@ -2,10 +2,17 @@ import argparse
 
 from . import pubCrawlLib
 
-def download_pmid(pmid, config={}):
+def download_pmid(pmid, config={}, return_info=False):
+    print(pmid, "Downloading meta")
     meta = pubCrawlLib.downloadPubmedMeta(str(pmid))
-    pdf_file = pubCrawlLib.crawlOneDoc(meta, doc_type='pdf', config=config)
-    return pdf_file
+    print(pmid, "Downloading oneDoc")
+    if return_info:
+        print(pmid, "Getting info as well")
+        pdf_file, crawl_info = pubCrawlLib.crawlOneDoc(meta, doc_type='pdf', config=config, return_info=return_info)
+        return pdf_file, crawl_info
+    else:
+        pdf_file = pubCrawlLib.crawlOneDoc(meta, doc_type='pdf', config=config, return_info=return_info)
+        return pdf_file
 
 def download_pmid_program():
     parser = argparse.ArgumentParser(description='Process some integers.')

--- a/pubMunch/pubCrawlLib.py
+++ b/pubMunch/pubCrawlLib.py
@@ -1783,7 +1783,9 @@ class HighwireCrawler(Crawler):
                 ipAddr = socket.gethostbyname(hostname)
                 self.hostCache[hostname] = ipAddr
             except socket.gaierror:
-                raise pubGetError("Illegal hostname %s in link" % hostname, "invalidHostname", hostname)
+                print("Highwire: Illegal hostname %s in link" % hostname)
+                return False
+                #raise pubGetError("Illegal hostname %s in link" % hostname, "invalidHostname", hostname)
 
         ipParts = ipAddr.split(".")
         ipParts = [int(x) for x in ipParts]

--- a/pubMunch/pubCrawlLib.py
+++ b/pubMunch/pubCrawlLib.py
@@ -742,7 +742,7 @@ def parseHtmlLinks(page, canBeOffsite=False, landingPage_ignoreUrlREs=[]):
                 content = l.get('content')
                 logging.log(5, 'found meta refresh tag: %s' % str(content))
                 if content != None:
-                    parts = string.split(content, '=', 1)
+                    parts = content.split("=", 1)
                     if len(parts)==2:
                         url = urllib.parse.urljoin(baseUrl, parts[1])
                         metaDict['refresh'] = url

--- a/pubMunch/pubCrawlLib.py
+++ b/pubMunch/pubCrawlLib.py
@@ -2040,9 +2040,11 @@ class WileyCrawler(Crawler):
 
         # pdf
         #pdfUrl = getMetaPdfUrl(mainPage)
-        pdfUrl = absUrl.replace("/abstract", "/pdf").replace("/full", "/pdf").replace("/abs", "/pdf")
-        pdfPage = httpGetDelay(pdfUrl, delayTime)
+        #pdfUrl = absUrl.replace("/abstract", "/pdf").replace("/full", "/pdf").replace("/abs", "/pdf")
+        pdfUrl = absUrl.replace("/pdf", "/pdfdirect").replace("/abstract", "/pdfdirect").replace("/full", "/pdfdirect").replace("/abs", "/pdfdirect")
+        pdfPage = httpGetDelay(pdfUrl, delayTime, accept="application/pdf")
         if not isPdf(pdfPage):
+            pdfPage = httpGetDelay(pdfUrl, delayTime)
             parseHtmlLinks(pdfPage)
             if "pdfDocument" in pdfPage["iframes"]:
                 logging.debug("found framed PDF, requesting inline pdf")


### PR DESCRIPTION
1) The LWW crawler's calls to parseHtmlLinks were resulting in errors when run with python3 as that function used python2's string.split function. 

2) In the crawlOneDoc function, there was this variable lastException that wasn't in use, and I think this is what its intended purpose is. Basically, rather than raising an error if a crawler fails, we catch it and move on to the next crawler. This resolved a lot of problems with the HighWire crawler as other crawlers seemed to work when it would fail. 