### PR TITLE
Fixes for NPG and Elsevier Crawlers

### DIFF
--- a/pubMunch/pubCrawlLib.py
+++ b/pubMunch/pubCrawlLib.py
@@ -1583,7 +1583,7 @@ class ElsevierCrawlerMixin(object):
         return ("sciencedirect.com" in url) or ("elsevier.com" in url)
 
 
-class ElsevierApiCrawler(Crawler, ElsevierCrawlerMixin):
+class ElsevierApiCrawler(ElsevierCrawlerMixin, Crawler):
     name = "elsevier-api"
 
     def canDo_url(self, url):
@@ -1611,7 +1611,7 @@ class ElsevierApiCrawler(Crawler, ElsevierCrawlerMixin):
         return paperData
 
 
-class ElsevierCrawler(Crawler, ElsevierCrawlerMixin):
+class ElsevierCrawler(ElsevierCrawlerMixin, Crawler):
     """ sciencedirect.com is Elsevier's hosting platform
     This crawler is minimalistic, we use ConSyn to get Elsevier text at UCSC.
 

--- a/pubMunch/pubCrawlLib.py
+++ b/pubMunch/pubCrawlLib.py
@@ -2999,7 +2999,6 @@ def selectCrawlers(artMeta, allCrawlers, config):
     crawlerNames = [c.name for c in okCrawlers]
     customCrawlers = set(crawlerNames) - set(["pmc", "generic"])
 
-
     if len(customCrawlers)==0:
         # get the landing URL from a search engine like pubmed or crossref
         # and ask the crawlers again
@@ -3007,6 +3006,13 @@ def selectCrawlers(artMeta, allCrawlers, config):
         landingUrl = getLandingUrlSearchEngine(artMeta, config)
 
         okCrawlers.extend(findCrawlers_url(landingUrl, allCrawlers))
+    
+    # sometimes "npg" articles lead to sciencedirect urls (which we need the Elsevier crawler for)
+    elif "npg" in customCrawlers:
+        logging.debug("npg crawler selected, check to see if Elsevier can grab instead")
+        landingUrl = getLandingUrlSearchEngine(artMeta, config)
+        elsevierCrawlers = [clz(config) for clz in [ElsevierApiCrawler, ElsevierCrawler]]
+        okCrawlers.extend(findCrawlers_url(landingUrl, elsevierCrawlers))
 
     if len(okCrawlers)==0:
         logging.info("No crawler found on either article metadata or URL.")

--- a/pubMunch/pubCrawlLib.py
+++ b/pubMunch/pubCrawlLib.py
@@ -1540,6 +1540,7 @@ class NpgCrawler(Crawler):
         delayTime = 5
         htmlPage = httpGetDelay(url, delayTime)
         if pageContains(htmlPage, ["make a payment", "purchase this article"]):
+            logging.debug("NPG hit paywall")
             return None
 
         if pageContains(htmlPage, ["This article appears in"]):
@@ -1554,6 +1555,7 @@ class NpgCrawler(Crawler):
         htmlPage["data"] = self._npgStripExtra(origHtml)
         paperData["main.html"] = htmlPage
 
+
         pdfUrl = getMetaPdfUrl(htmlPage)
         if pdfUrl is None:
             url = htmlPage["url"].rstrip("/")
@@ -1562,6 +1564,12 @@ class NpgCrawler(Crawler):
                 pdfUrl = url+".pdf"
             else:
                 pdfUrl = url.replace("/full/", "/pdf/").replace(".html", ".pdf")
+            
+            # https://www.nature.com/articles/s41415-020-1339-7
+            # occasionally no .html at the end, in which case we can just add .pdf
+            if not pdfUrl.endswith(".pdf"):
+                pdfUrl += ".pdf"
+
         pdfPage = httpGetDelay(pdfUrl, delayTime)
         paperData["main.pdf"] = pdfPage
 

--- a/pubMunch/pubCrawlLib.py
+++ b/pubMunch/pubCrawlLib.py
@@ -1140,6 +1140,7 @@ def findCrawlers_article(artMeta, allCrawlers):
     """
     crawlers = []
     for c in allCrawlers:
+        logging.debug("Checking if crawler %s will work" % c.name)
         if c.canDo_article(artMeta):
             logging.log(5, "Based on meta data: Crawler %s is OK to crawl article %s" % (c.name, artMeta["title"]))
             crawlers.append(c)
@@ -1572,6 +1573,7 @@ class ElsevierCrawlerMixin(object):
     def canDo_article(self, artMeta):
         " return true if DOI prefix is by elsevier "
         pList = ["10.1378", "10.1016", "10.1038"]
+        logging.debug("Checking if Elsevier can handle doi: %s" % artMeta["doi"])
         for prefix in pList:
             if artMeta["doi"].startswith(prefix):
                 return True


### PR DESCRIPTION
A lot of articles that were failing on the NPG crawler were actually better handled by the Elsevier crawlers. This was caused by an inheritance issue between the Elsevier crawlers, the ElsevierCrawlerMixin class, and the Crawler class. The two actual crawlers (ElsevierCrawler and ElsevierApiCrawler) were using the base Crawler's method to determine whether or not the crawler could handle an article (which always returns false), instead of ElsevierCrawlerMixin's method (which checks the DOI). This was fixed by just swapping the two in the class definition. 

I'm guessing that this fix will help catch a bunch more articles as well (not just NPG ones). Without this change, the only way the Elsevier crawlers are ever used is if all the other crawlers can't handle the article, and PubMunch falls back on the landing url method to decide which crawlers to use. 

Other fixes include adding .pdf to NPG articles that don't end in .html (caught a couple extra articles), and checking to see if an article is better suited for one of the Elsevier crawlers if NPG is the only custom crawler chosen based on article metadata (caught a couple more articles). 