### PR TITLE
Adding support for a fallback proxy for each crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ pip-log.txt
 # vim temporary files
 *.swp
 venv
+
+.DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ pip-log.txt
 # vim temporary files
 *.swp
 venv
+
+# user pubConf
+doc/pubConf.py

--- a/doc/pubConf.example
+++ b/doc/pubConf.example
@@ -26,6 +26,14 @@ consynRssUrl = "https://consyn.elsevier.com/batch/atom?key=XXXXXXXXXX"
 # the temporary directory
 TEMPDIR = "/tmp/"
 
-# If you use a proxy server to get fulltext access, enter it here
+# If you want to use the same proxy server to get fulltext access to all articles, enter it here
 # httpProxy="http://myserver.com:8888"
 
+# If you want to specify different proxies for different crawlers, set them here
+proxies = {
+    "proxy_name": {"http":"http://myserver.com:8888"},
+}
+
+crawler_to_proxy = {
+    "crawler_name": "proxy_name",
+}

--- a/pubMunch/pubConf.py
+++ b/pubMunch/pubConf.py
@@ -11,11 +11,14 @@ if (confName is not None) and not isfile(confName):
 if confName is None:
     confName = expanduser("~/.pubConf")
 newVars = {}
+print(isfile(confName))
 if isfile(confName):
     exec(compile(open(confName).read(), confName, 'exec'), {}, newVars)
+    print(newVars)
     for key, value in newVars.items():
+        print(key, value)
         locals()[key] = value
-
+print("confName", confName)
 # GENERAL SETTINGS   ================================================
 # baseDir for internal data, accessible from cluster 
 # used for data created during pipeline runs
@@ -114,8 +117,13 @@ httpTimeout = 5
 # after this the download will be canceled and the paper marked as unsuccessful
 httpTransferTimeout = 60
 
-# if you need to use a proxy to access journals, set it here
+# if you want to set a global proxy to access all journals, set it here
 httpProxy = None
+
+# if you want to use different proxies for different crawlers, set them here
+proxies = {}
+crawler_to_proxy = {}
+
 
 # SFX server for pubmed entries without an outlink
 # YOU NEED TO DEFINE THIS IF YOU WANT TO USE SFX

--- a/pubMunch/pubConf.py
+++ b/pubMunch/pubConf.py
@@ -11,14 +11,11 @@ if (confName is not None) and not isfile(confName):
 if confName is None:
     confName = expanduser("~/.pubConf")
 newVars = {}
-print(isfile(confName))
 if isfile(confName):
     exec(compile(open(confName).read(), confName, 'exec'), {}, newVars)
-    print(newVars)
     for key, value in newVars.items():
-        print(key, value)
         locals()[key] = value
-print("confName", confName)
+
 # GENERAL SETTINGS   ================================================
 # baseDir for internal data, accessible from cluster 
 # used for data created during pipeline runs

--- a/pubMunch/pubCrawlLib.py
+++ b/pubMunch/pubCrawlLib.py
@@ -1131,7 +1131,7 @@ def checkIssnErrorCounts(pubmedMeta, ignoreIssns, outDir):
         raise pubGetError("a previous run disabled this issn+year", "issnYearErrorExceed-old", \
             "%s %s" % issnYear)
 
-ddef resolveDoi(doi):
+def resolveDoi(doi):
     """ resolve a DOI to the final target url or None on error
     >>> logging.warn("doi test")
     >>> resolveDoi("10.1111/j.1440-1754.2010.01952.x").split(";")[0]
@@ -1410,6 +1410,7 @@ def addSuppZipFiles(suppZipUrl, paperData, delayTime, proxy=None):
         paperData["S"+str(suppIdx+1)+fileExt] = page
 
 class DeGruyterCrawler(Crawler):
+    name = "degruyter"
     def canDo_url(self, url):
         return ("www.degruyter.com" in url)
 
@@ -2147,7 +2148,6 @@ class LwwCrawler(Crawler):
     """
 
     name = "lww"
-
     issnList = None
 
     def __init__(self, config):
@@ -3061,7 +3061,7 @@ def crawlOneDoc(artMeta, forceCrawlers=False, doc_type='pdf', config={}, return_
         crawlers, landingUrl = selectCrawlers(artMeta, allCrawlers, config)
     else:
         # just use the crawlers we got
-        logging.debug("Crawlers were fixed externally: %s" % ",".join(allCrawlerClasses))
+        #logging.debug("Crawlers were fixed externally: %s" % ",".join(allCrawlerClasses))
         cByName = {}
         for c in allCrawlers:
             cByName[c.name] = c
@@ -3105,9 +3105,9 @@ def crawlOneDoc(artMeta, forceCrawlers=False, doc_type='pdf', config={}, return_
 
             # if failed for whatever reason, and there's an alternate proxy available, try it
             if paperData is None or not isPdf(paperData["main.pdf"]) or (doc_type == 'pdf' and 'main.pdf' not in paperData):
-                print("Couldn't grab PDF, trying again with proxy")
                 proxy = get_crawler_proxy(crawler.name) # returns {} if no proxy specified
                 if proxy:
+                    print("Couldn't grab PDF, trying again with proxy")
                     paperData = crawler.crawl(url, proxy=proxy)
             
             if paperData is None:
@@ -3127,10 +3127,8 @@ def crawlOneDoc(artMeta, forceCrawlers=False, doc_type='pdf', config={}, return_
                     return paperData['main.pdf']['data'], crawlInfo
 
             elif not return_info:
-                print("A")
                 return paperData['main.html']['data']
             else:
-                print("B")
                 crawlInfo["succeeded"] = crawler.name
                 return paperData['main.pdf']['data'], crawlInfo
 

--- a/pubMunch/pubPubmed.py
+++ b/pubMunch/pubPubmed.py
@@ -442,26 +442,26 @@ def getOutlinks(pmid, preferPmc=False):
     isPmc = False
 
     for line in html:
-        if line.find("<ObjUrl>") != -1:
+        if line.find("<ObjUrl>") != None:
             url=""
             fullText=False
             origPublisher=False
-        if line.find("Attribute") != -1:
+        if line.find("Attribute") != None:
             attribute=stripTag(line)
             if attribute.lower()=="full-text online" or attribute=="full-text pdf":
                 fullText=True
-        if line.find("<NameAbbr>") != -1 and fullText and origPublisher:
+        if line.find("<NameAbbr>") != None and fullText and origPublisher:
             db = stripTag(line)
             outlinks[db]=url
-        if line.find("publishers/providers")!=-1:
+        if line.find("publishers/providers")!=None:
             origPublisher=True
-        if line.find("<Provider>") != -1:
+        if line.find("<Provider>") != None:
             provider=True
-        if line.find("</Provider>") != -1:
+        if line.find("</Provider>") != None:
             provider=False
-        if line.find("<DbFrom>") != -1:
+        if line.find("<DbFrom>") != None:
             db = stripTag(line)
-        if line.find("<Url>") != -1 and not provider:
+        if line.find("<Url>") != None and not provider:
             url = line
             url = stripTag(url).replace("&amp;", "&") # XX strange!
             url = stripTag(url).replace("&lt;", "<")


### PR DESCRIPTION
Most of the changes are in pubCrawlLib. Basically just adding a proxy parameter to the httpGetDelay function that's used throughout the crawlers. If a user specifies a proxy dict in their pubConf file (see pubConf.example), then if that crawler fails, we will retry the crawl but through the proxy. When retrying through the proxy, we avoid returning the already cached html for the page (i.e. force it to actually try again). 

Tested by forcing each crawler to retry a PMID that it failed on previously, then seeing if it would retry using a given proxy. No immediate errors, but I wouldn't rule out the possibility of some unexpected behavior popping up as we use this feature more. 